### PR TITLE
Swift & Xcode 7 Compatibility Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 # * https://github.com/supermarin/xcpretty#usage
 
 language: objective-c
+osx_image: xcode7
 # cache: cocoapods
 # podfile: Example/Podfile
 # before_install:

--- a/Example/OALayoutAnchor/Main.storyboard
+++ b/Example/OALayoutAnchor/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8121.20" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="whP-gf-Uak">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8101.16"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -16,12 +16,13 @@
                     <view key="view" contentMode="scaleToFill" id="TpU-gO-2f1">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tc2-Qw-aMS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="141" y="276"/>
+            <point key="canvasLocation" x="165" y="-180"/>
         </scene>
         <!--View Controller2-->
         <scene sceneID="ddf-1b-mBT">
@@ -34,12 +35,13 @@
                     <view key="view" contentMode="scaleToFill" id="e41-Fn-rWL">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="E0I-vJ-7U7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="141" y="276"/>
+            <point key="canvasLocation" x="165" y="474"/>
         </scene>
     </scenes>
 </document>

--- a/Example/OALayoutAnchor/OAViewController2.swift
+++ b/Example/OALayoutAnchor/OAViewController2.swift
@@ -16,7 +16,7 @@ class OAViewController2: UIViewController {
     let view1 = UIView()
     view1.backgroundColor = UIColor.blueColor()
     
-    view1.setTranslatesAutoresizingMaskIntoConstraints(false)
+    view1.translatesAutoresizingMaskIntoConstraints = false
     self.view.addSubview(view1)
     view1.oa_widthAnchor.constraintEqualToConstant(100).oa_active = true
     view1.oa_heightAnchor.constraintEqualToConstant(100).oa_active = true

--- a/Pod/Classes/UIView+LayoutAnchorSwift.h
+++ b/Pod/Classes/UIView+LayoutAnchorSwift.h
@@ -13,7 +13,7 @@
 //To fix this you can guard agains the api. However, for a more transparent usage for anchors on ios
 //7,8 and 9, if you are using swift, use oa_ prefixed version.
 
-#ifndef __IPHONE_9_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 90000
 #import <OALayoutAnchor/UIView+OALayoutAnchor.h>
 #import <OALayoutAnchor/OALayoutAnchor.h>
 #define NSLayoutXAxisAnchor OALayoutXAxisAnchor

--- a/Pod/Classes/UIView+LayoutAnchorSwift.h
+++ b/Pod/Classes/UIView+LayoutAnchorSwift.h
@@ -8,10 +8,10 @@
 
 #import <UIKit/UIKit.h>
 
-//These helpers have been added to make swift comiplation works
-//In swift apis that are available for an iOS version and up, wont compile.
-//To fix this you can guard agains the api. However, for a more transparent usage for anchors on ios
-//7,8 and 9, if you are using swift, use oa_ prefixed version.
+// These helpers have been added to make Swift compilation work
+// In Swift, APIs that are available for an iOS version and up wont compile on older SDK versions.
+// To fix this you can guard against the API. However, for a more transparent usage for anchors on iOS
+// 7, 8, and 9, if you are using Swift, use oa_ prefixed version.
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 90000
 #import <OALayoutAnchor/UIView+OALayoutAnchor.h>

--- a/Pod/Classes/UIView+LayoutAnchorSwift.h
+++ b/Pod/Classes/UIView+LayoutAnchorSwift.h
@@ -14,8 +14,8 @@
 // 7, 8, and 9, if you are using Swift, use oa_ prefixed version.
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 90000
-#import <OALayoutAnchor/UIView+OALayoutAnchor.h>
-#import <OALayoutAnchor/OALayoutAnchor.h>
+#import "UIView+OALayoutAnchor.h"
+#import "OALayoutAnchor.h"
 #define NSLayoutXAxisAnchor OALayoutXAxisAnchor
 #define NSLayoutYAxisAnchor OALayoutYAxisAnchor
 #define NSLayoutDimension OALayoutDimension


### PR DESCRIPTION
The primary change here is switching the preprocessor guard in `UIView+LayoutAnchorSwift.h` from `#ifndef __IPHONE_9_0` to `#if __IPHONE_OS_VERSION_MIN_REQUIRED < 90000`. This causes the `oa_layout` properties on `UIView` to be defined as `OALayout` classes in projects built against the iOS 9 SDK with a deployment target less than 9. This works around issues where methods or variables couldn't store references to anchors returned by `oa_layout` properties in Swift because the `NSLayoutAnchor` classes are unavailable.

Other small fixes:
- Update the Swift example view controller to build in Xcode 7
- Fix the example Storyboard so the two view controllers aren't on top of each other
- Change the imports in `UIView+LayoutAnchorSwift.h` to use local `""` style imports rather than framework `<>` imports. Without this, Xcode 7 gives the error `include of non-modular header inside framework module 'OALayoutAnchor.UIView_LayoutAnchorSwift'` when `OALayoutAnchor` is installed via CocoaPods
- Small comment typo/cleanup

Thanks for a great library!
